### PR TITLE
Meetups and talks

### DIFF
--- a/app/components/MeetupCard.tsx
+++ b/app/components/MeetupCard.tsx
@@ -8,7 +8,9 @@ type MeetupCardProps = {
 
 const MeetupCard: FC<MeetupCardProps> = ({ meetup }) => {
     if (!meetup) {
-        return <p>No upcoming meetups</p>;
+        return (
+            <em>The next meetup has not been scheduled yet. Check back soon for more details!</em>
+        );
     }
 
     return (

--- a/app/components/MeetupCard.tsx
+++ b/app/components/MeetupCard.tsx
@@ -1,0 +1,25 @@
+import type { FC } from "react";
+import LinkButton from "./LinkButton";
+
+type MeetupCardProps = {
+    // biome-ignore lint/suspicious/noExplicitAny: Fix this later
+    meetup: any;
+};
+
+const MeetupCard: FC<MeetupCardProps> = ({ meetup }) => {
+    if (!meetup) {
+        return <p>No upcoming meetups</p>;
+    }
+
+    return (
+        <article className="rounded-lg p-8">
+            <h3>{meetup.title}</h3>
+
+            <LinkButton target="_blank" to={meetup.eventUrl}>
+                View on Meetup
+            </LinkButton>
+        </article>
+    );
+};
+
+export default MeetupCard;

--- a/app/components/MeetupCard.tsx
+++ b/app/components/MeetupCard.tsx
@@ -1,9 +1,9 @@
 import type { FC } from "react";
 import LinkButton from "./LinkButton";
+import type { Meetup } from "~/utils/meetup";
 
 type MeetupCardProps = {
-    // biome-ignore lint/suspicious/noExplicitAny: Fix this later
-    meetup: any;
+    meetup: Meetup;
 };
 
 const MeetupCard: FC<MeetupCardProps> = ({ meetup }) => {

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -10,10 +10,18 @@ type TalkCardProps = {
 const TalkCard: FC<TalkCardProps> = ({ talk }) => {
     return (
         <Link target="_blank" to={talk.eventUrl}>
-            <article className="rounded-lg border-2 p-8">
-                <p>{formatDate(talk.dateTime)}</p>
-                <h4 className="mb-6 font-bold text-3xl">{talk.title}</h4>
-                <p>{`${talk.rsvps.yesCount} attendees`}</p>
+            <article className="grid grid-cols-[auto_1fr] gap-x-8 rounded-lg border-2 p-8">
+                <img
+                    alt={talk.title}
+                    className="h-64 w-full border-2 object-cover"
+                    src="https://i.ytimg.com/vi/kMa4zmvlHFI/maxresdefault.jpg"
+                />
+
+                <div>
+                    <p>{formatDate(talk.dateTime)}</p>
+                    <h4 className="mb-6 font-bold text-3xl">{talk.title}</h4>
+                    <p>{`${talk.rsvps.yesCount} attendees`}</p>
+                </div>
             </article>
         </Link>
     );

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -1,0 +1,22 @@
+import type { FC } from "react";
+import { Link } from "react-router";
+import { formatDate } from "~/utils/date";
+
+type TalkCardProps = {
+    // biome-ignore lint/suspicious/noExplicitAny: Fix this later
+    talk: any;
+};
+
+const TalkCard: FC<TalkCardProps> = ({ talk }) => {
+    return (
+        <Link target="_blank" to={talk.eventUrl}>
+            <article className="rounded-lg border-2 p-8">
+                <p>{formatDate(talk.dateTime)}</p>
+                <h4 className="mb-6 font-bold text-3xl">{talk.title}</h4>
+                <p>{`${talk.rsvps.yesCount} attendees`}</p>
+            </article>
+        </Link>
+    );
+};
+
+export default TalkCard;

--- a/app/components/TalkCard.tsx
+++ b/app/components/TalkCard.tsx
@@ -1,10 +1,10 @@
 import type { FC } from "react";
 import { Link } from "react-router";
 import { formatDate } from "~/utils/date";
+import type { Meetup } from "~/utils/meetup";
 
 type TalkCardProps = {
-    // biome-ignore lint/suspicious/noExplicitAny: Fix this later
-    talk: any;
+    talk: Meetup;
 };
 
 const TalkCard: FC<TalkCardProps> = ({ talk }) => {

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -11,8 +11,7 @@ export async function loader() {
 }
 
 export default function Home({ loaderData }: Route.ComponentProps) {
-    const nextMeetup = loaderData.events.nextMeetup.edges[0]?.node;
-    const previousTalks = loaderData.events.previousTalks.edges;
+    const { nextMeetup, previousTalks } = loaderData.events;
 
     return (
         <>
@@ -59,10 +58,8 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         Previous Talks
                     </h2>
 
-                    {/* @ts-expect-error: Fix this later */}
                     {previousTalks.map(previousTalk => {
-                        const talk = previousTalk.node;
-                        return <TalkCard key={talk.id} talk={talk} />;
+                        return <TalkCard key={previousTalk.id} talk={previousTalk} />;
                     })}
 
                     <button className="justify-self-end" type="button">

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -47,7 +47,7 @@ export default function Home({ loaderData }: Route.ComponentProps) {
 
             <main className="grid gap-36 px-20 py-20">
                 <section>
-                    <h2 className="font-bold text-5xl text-black" id="next-meetup">
+                    <h2 className="mb-12 font-bold text-5xl text-black" id="next-meetup">
                         Next Meetup
                     </h2>
 

--- a/app/routes/_index/route.tsx
+++ b/app/routes/_index/route.tsx
@@ -2,6 +2,8 @@ import LinkButton from "~/components/LinkButton";
 import logo from "~/icons/logo.svg";
 import { getEvents } from "~/utils/meetup";
 import type { Route } from "./+types/route";
+import MeetupCard from "~/components/MeetupCard";
+import TalkCard from "~/components/TalkCard";
 
 export async function loader() {
     const events = await getEvents();
@@ -9,8 +11,8 @@ export async function loader() {
 }
 
 export default function Home({ loaderData }: Route.ComponentProps) {
-    const { events } = loaderData;
-    console.log(events);
+    const nextMeetup = loaderData.events.nextMeetup.edges[0]?.node;
+    const previousTalks = loaderData.events.previousTalks.edges;
 
     return (
         <>
@@ -34,6 +36,10 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         GitHub
                     </LinkButton>
 
+                    <LinkButton target="_blank" to="https://youtube.com/@remixaustin">
+                        YouTube
+                    </LinkButton>
+
                     <LinkButton to="/signin">Sign In</LinkButton>
                     <LinkButton to="/talks/submit">Give Talk</LinkButton>
                 </div>
@@ -45,15 +51,23 @@ export default function Home({ loaderData }: Route.ComponentProps) {
                         Next Meetup
                     </h2>
 
-                    <p>todo</p>
+                    <MeetupCard meetup={nextMeetup} />
                 </section>
 
-                <section>
+                <section className="grid gap-y-12">
                     <h2 className="font-bold text-5xl text-black" id="previous-talks">
                         Previous Talks
                     </h2>
 
-                    <p>todo</p>
+                    {/* @ts-expect-error: Fix this later */}
+                    {previousTalks.map(previousTalk => {
+                        const talk = previousTalk.node;
+                        return <TalkCard key={talk.id} talk={talk} />;
+                    })}
+
+                    <button className="justify-self-end" type="button">
+                        View more
+                    </button>
                 </section>
             </main>
         </>

--- a/app/utils/date.ts
+++ b/app/utils/date.ts
@@ -1,0 +1,16 @@
+const formatDate = (date: string) => {
+    const options: Intl.DateTimeFormatOptions = {
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+    };
+
+    const formatter = new Intl.DateTimeFormat("en-US", options);
+    const formattedDate = formatter.format(new Date(date));
+
+    return formattedDate;
+};
+
+export { formatDate };

--- a/app/utils/meetup.ts
+++ b/app/utils/meetup.ts
@@ -10,10 +10,11 @@ const MeetupQuery = gql`
         groupByUrlname(urlname: $urlname) {
             id
             name
-            currentEvent:events(status:ACTIVE, sort:DESC, first:1) {
+            nextMeetup: events(status:ACTIVE, sort:DESC, first:1) {
                 totalCount
                 edges {
                     node {
+                        id
                         title
                         description
                         eventUrl
@@ -24,10 +25,11 @@ const MeetupQuery = gql`
                     }
                 }
             }
-            pastEvents:events(status:PAST, sort:DESC, first:5) {
+            previousTalks: events(status:PAST, sort:DESC, first:5) {
                 totalCount
                 edges {
                     node {
+                        id
                         title
                         eventUrl
                         dateTime

--- a/app/utils/meetup.ts
+++ b/app/utils/meetup.ts
@@ -1,5 +1,16 @@
 import { Client, gql, cacheExchange, fetchExchange } from "@urql/core";
 
+type Meetup = {
+    id: string;
+    title: string;
+    description: string;
+    eventUrl: string;
+    dateTime: string;
+    rsvps: {
+        yesCount: number;
+    };
+};
+
 const client = new Client({
     url: "https://api.meetup.com/gql-ext",
     exchanges: [cacheExchange, fetchExchange],
@@ -44,8 +55,28 @@ const MeetupQuery = gql`
 
 const getEvents = async () => {
     const response = await client.query(MeetupQuery, { urlname: "remix-austin" }).toPromise();
-    const events = response.data.groupByUrlname;
+
+    const nextMeetup: Meetup = response.data.groupByUrlname.nextMeetup.edges[0]?.node;
+
+    const previousTalks: Meetup[] = response.data.groupByUrlname.previousTalks.edges.map(
+        (edge: { node: Meetup }) => ({
+            id: edge.node.id,
+            title: edge.node.title,
+            eventUrl: edge.node.eventUrl,
+            dateTime: edge.node.dateTime,
+            rsvps: {
+                yesCount: edge.node.rsvps.yesCount,
+            },
+        }),
+    );
+
+    const events = {
+        nextMeetup,
+        previousTalks,
+    };
+
     return events;
 };
 
 export { getEvents };
+export type { Meetup };


### PR DESCRIPTION
- Add `<MeetupCard>` and `<TalkCard>` components
- Add `formatDate()` helper function
- Show next meetup and previous talks on home page
- Add hard coded `Meetup` type

@markmals This all still needs to by styled / designed correctly. I just wanted to get the data on the page.

![home](https://github.com/user-attachments/assets/a4401a87-f8dd-4ecd-a087-913b414666db)
